### PR TITLE
feat: add github contribution graph

### DIFF
--- a/components/GitHubGraph.tsx
+++ b/components/GitHubGraph.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { GitHubCalendar } from "react-github-calendar";
+import { useEffect, useRef, useState } from "react";
+import { social } from "../lib/social-links";
+import { FiExternalLink } from "react-icons/fi";
+import { Heading } from "./Heading";
+import { LinkTag } from "./LinkTag";
+import { Section } from "./Section";
+import { Text } from "./Text";
+
+const GITHUB_USERNAME = social.github.username;
+
+// Tints derived from the site's primary green (#30D158), going from the
+// "no contributions" cell up to the most active.
+const CALENDAR_THEME = {
+  light: ["#ebedf0", "#a7e8b9", "#6cdb8c", "#30d158", "#1f9b41"],
+  dark: ["#161b22", "#0e4429", "#15803d", "#30d158", "#5ee37f"],
+};
+
+export const GitHubGraph = () => {
+  const [colorScheme, setColorScheme] = useState<"light" | "dark">("dark");
+  // The calendar is browser-only (it fetches data and reads the theme class),
+  // so we gate it behind mount to avoid an SSR/client hydration mismatch.
+  const [mounted, setMounted] = useState(false);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setMounted(true);
+
+    const html = document.documentElement;
+
+    const syncColorScheme = () => {
+      setColorScheme(html.classList.contains("dark") ? "dark" : "light");
+    };
+
+    syncColorScheme();
+
+    const observer = new MutationObserver(syncColorScheme);
+    observer.observe(html, { attributes: true, attributeFilter: ["class"] });
+
+    return () => observer.disconnect();
+  }, []);
+
+  // The graph spans a year, so on smaller screens it overflows horizontally.
+  // react-activity-calendar renders its own internal horizontal scroll
+  // container, so we pin *that* element to the right (the most recent
+  // contributions). Its width only settles once the data has loaded, so we
+  // re-pin on any content mutation or resize.
+  useEffect(() => {
+    if (!mounted) return;
+
+    const container = scrollRef.current;
+    if (!container) return;
+
+    const pinToRight = () => {
+      const scroller =
+        container.querySelector<HTMLElement>("article > div") ?? container;
+      scroller.scrollLeft = scroller.scrollWidth;
+    };
+
+    pinToRight();
+
+    const resizeObserver = new ResizeObserver(pinToRight);
+    resizeObserver.observe(container);
+
+    const mutationObserver = new MutationObserver(pinToRight);
+    mutationObserver.observe(container, { childList: true, subtree: true });
+
+    return () => {
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
+    };
+  }, [mounted]);
+
+  return (
+    <Section>
+      <Heading>GitHub 🐙</Heading>
+      <Text>Here&apos;s a snapshot of my contribution activity on GitHub.</Text>
+      <div ref={scrollRef} className="mt-6 min-h-[160px]">
+        {mounted && (
+          <GitHubCalendar
+            username={GITHUB_USERNAME}
+            colorScheme={colorScheme}
+            theme={CALENDAR_THEME}
+            fontSize={14}
+            blockSize={12}
+          />
+        )}
+      </div>
+      <div className="flex mt-6">
+        <LinkTag href={social.github.link} target="_blank">
+          View my profile on GitHub <FiExternalLink className="text-lg ml-1" />
+        </LinkTag>
+      </div>
+    </Section>
+  );
+};

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "pg": "^8.18.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-github-calendar": "^5.0.6",
     "react-icons": "^4.3.1",
     "react-tippy": "^1.4.0",
     "react-tweet": "^3.3.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
 import { FeaturedArticles } from "../components/FeaturedArticles";
 import { Technologies } from "../components/Technologies";
+import { GitHubGraph } from "../components/GitHubGraph";
 import { FULL_NAME, PROFESSION } from "../lib/constants";
 import { Experience } from "../components/Experience";
 import { NewsLetter } from "../components/Newsletter";
@@ -35,6 +36,7 @@ const Home: NextPage = () => {
           <Experience />
           <Technologies />
           <Education />
+          <GitHubGraph />
           {/* <Projects /> */}
           <Music />
           <Community />

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,6 +122,13 @@
   dependencies:
     "@floating-ui/utils" "^0.2.10"
 
+"@floating-ui/core@^1.7.5":
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.7.5.tgz#d4af157a03330af5a60e69da7a4692507ada0622"
+  integrity sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==
+  dependencies:
+    "@floating-ui/utils" "^0.2.11"
+
 "@floating-ui/dom@^1.7.4":
   version "1.7.4"
   resolved "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz"
@@ -130,6 +137,14 @@
     "@floating-ui/core" "^1.7.3"
     "@floating-ui/utils" "^0.2.10"
 
+"@floating-ui/dom@^1.7.6":
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.7.6.tgz#f915bba5abbb177e1f227cacee1b4d0634b187bf"
+  integrity sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==
+  dependencies:
+    "@floating-ui/core" "^1.7.5"
+    "@floating-ui/utils" "^0.2.11"
+
 "@floating-ui/react-dom@^2.0.0":
   version "2.1.6"
   resolved "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz"
@@ -137,10 +152,31 @@
   dependencies:
     "@floating-ui/dom" "^1.7.4"
 
+"@floating-ui/react-dom@^2.1.8":
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.8.tgz#5fb5a20d10aafb9505f38c24f38d00c8e1598893"
+  integrity sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==
+  dependencies:
+    "@floating-ui/dom" "^1.7.6"
+
+"@floating-ui/react@^0.27.19":
+  version "0.27.19"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.27.19.tgz#d8d5d895b7cb97dac370bfbf55f3e630878fdf1f"
+  integrity sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==
+  dependencies:
+    "@floating-ui/react-dom" "^2.1.8"
+    "@floating-ui/utils" "^0.2.11"
+    tabbable "^6.0.0"
+
 "@floating-ui/utils@^0.2.10":
   version "0.2.10"
   resolved "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz"
   integrity sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==
+
+"@floating-ui/utils@^0.2.11":
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.11.tgz#a269e055e40e2f45873bae9d1a2fdccbd314ea3f"
+  integrity sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==
 
 "@headlessui/react@^1.6.4":
   version "1.7.19"
@@ -2076,6 +2112,11 @@ data-view-byte-offset@^1.0.1:
     call-bound "^1.0.2"
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
+
+date-fns@^4.1.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.4.0.tgz#806539edf45c616b2b76b5f78b88c56ed3c7e036"
+  integrity sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==
 
 dayjs@^1.11.2:
   version "1.11.19"
@@ -4736,6 +4777,14 @@ rc9@^2.1.2:
     defu "^6.1.4"
     destr "^2.0.3"
 
+react-activity-calendar@^3.1.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-activity-calendar/-/react-activity-calendar-3.2.0.tgz#9d29425eccb59eccf62a2c27e6c96dc977adb3d5"
+  integrity sha512-v+ZD61h7RB76YMDh1aGAZuoXsSymSixKMOMusMoYWxhDXkFUX6hiftHin/tWqIS9zSNA/NN+vzYDK4hPF0wuxQ==
+  dependencies:
+    "@floating-ui/react" "^0.27.19"
+    date-fns "^4.1.0"
+
 react-dom@^18.2.0:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz"
@@ -4743,6 +4792,13 @@ react-dom@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
+
+react-github-calendar@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/react-github-calendar/-/react-github-calendar-5.0.6.tgz#3d55156a6ac6a416b6d0023d2cf204f198658009"
+  integrity sha512-BXgk1blzmkXjzc3CJRtSxscNuL0y/pHHVihmY+H+8bak0Syg2G/7gCM4Ja6CzE5wtABDv6N97kKSufWqMazq/g==
+  dependencies:
+    react-activity-calendar "^3.1.2"
 
 react-icons@^4.3.1:
   version "4.12.0"
@@ -5405,6 +5461,11 @@ swr@^2.2.4:
   dependencies:
     dequal "^2.0.3"
     use-sync-external-store "^1.6.0"
+
+tabbable@^6.0.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.4.0.tgz#36eb7a06d80b3924a22095daf45740dea3bf5581"
+  integrity sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==
 
 tailwind-merge@^3.3.1:
   version "3.4.0"


### PR DESCRIPTION
This pull request introduces a new `GitHubGraph` component to display a user's GitHub contribution activity on the homepage. It leverages the `react-github-calendar` library, adapts to light/dark themes, and ensures proper rendering on both desktop and mobile devices. The component is integrated into the main page, and the required dependency is added.

**New GitHub contribution graph feature:**

* Added a new `GitHubGraph` component in `components/GitHubGraph.tsx` that displays a themed GitHub contributions calendar, handles color scheme changes, and ensures horizontal scrolling works well on smaller screens.
* Integrated the `GitHubGraph` component into the homepage by importing and rendering it in `pages/index.tsx`. [[1]](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3R3) [[2]](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3R39)

**Dependency updates:**

* Added the `react-github-calendar` package to `package.json` to enable the new GitHub contribution graph functionality.