### PR TITLE
chore: fix vercel issue

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  outputFileTracingIncludes: {
+    "/sitemap.xml": ["./posts/**/*"],
+  },
   images: {
     qualities: [99, 100],
     remotePatterns: [

--- a/pages/sitemap.xml.ts
+++ b/pages/sitemap.xml.ts
@@ -28,17 +28,23 @@ const url = (path: string, priority: string) => {
 };
 
 const generateSiteMap = () => {
-  const blogs = getAllPostSlugs(BLOGS_DIR).map(
-    ({ params }) => `${page.blog.path}/${params.slug}`
-  );
-  const notes = getAllPostSlugs(NOTES_DIR).map(
-    ({ params }) => `${page.note.path}/${params.slug}`
-  );
+  let posts: string[] = [];
+  try {
+    const blogs = getAllPostSlugs(BLOGS_DIR).map(
+      ({ params }) => `${page.blog.path}/${params.slug}`
+    );
+    const notes = getAllPostSlugs(NOTES_DIR).map(
+      ({ params }) => `${page.note.path}/${params.slug}`
+    );
+    posts = [...blogs, ...notes];
+  } catch (error) {
+    console.error("Failed to read posts for sitemap:", error);
+  }
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${STATIC_PATHS.map((path) => url(path, path === "/" ? "1.0" : "0.8")).join("\n")}
-${[...blogs, ...notes].map((path) => url(path, "0.6")).join("\n")}
+${posts.map((path) => url(path, "0.6")).join("\n")}
 </urlset>`;
 };
 


### PR DESCRIPTION
This pull request improves the robustness of the `generateSiteMap` function in `pages/sitemap.xml.ts` by adding error handling around the logic that reads blog and note post slugs. This ensures that if reading the post slugs fails, the sitemap generation will not crash and an error will be logged.

**Error handling improvements:**

* Wrapped the logic for reading blog and note post slugs in a `try-catch` block to handle errors gracefully and log a descriptive error message if post reading fails.
* Updated the sitemap XML generation to use a `posts` array that is safely populated only if post reading succeeds, preventing potential runtime errors.