### PR TITLE
add search for long posts

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -3,6 +3,8 @@ import { Footer } from "./Footer";
 import { Nav } from "./Nav";
 
 interface Props {
+  /** Rendered HTML of a long post, which gets a heading search next to the theme toggle. */
+  searchableContentHtml?: string;
   supportLargeScreen?: boolean;
   backButtonLocation?: string;
   children?: React.ReactNode;
@@ -36,6 +38,7 @@ export const Layout = (props: Props) => {
           className={`${supportLargeScreen ? "lg:block" : "lg:block hidden"}`}
         >
           <Nav
+            searchableContentHtml={props.searchableContentHtml}
             isDisplaySpotify={props.isDisplaySpotify}
             longLayoutFormat={props.longLayoutFormat}
           />

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -1,5 +1,6 @@
 import { NavDropdown } from "./NavDropdown";
 import { NavLinkTag } from "./NavLinkTag";
+import { PostSearch } from "./PostSearch";
 import { ITEMS } from "../lib/nav-items";
 import { Toggle } from "./Toggle";
 
@@ -7,6 +8,8 @@ import { Toggle } from "./Toggle";
 import { useRouter } from "next/router";
 
 interface Props {
+  /** Rendered HTML of a long post, which gets a heading search next to the theme toggle. */
+  searchableContentHtml?: string;
   isDisplaySpotify?: boolean;
   longLayoutFormat?: boolean;
 }
@@ -40,7 +43,12 @@ export const Nav = (props: Props) => {
           </NavLinkTag>
         ))}
       </div>
-      <Toggle />
+      <div className="flex items-center gap-2 ml-auto">
+        {props.searchableContentHtml ? (
+          <PostSearch contentHtml={props.searchableContentHtml} />
+        ) : null}
+        <Toggle />
+      </div>
     </nav>
   );
 };

--- a/components/Post.tsx
+++ b/components/Post.tsx
@@ -1,4 +1,4 @@
-import { DOMAIN, FULL_NAME } from "../lib/constants";
+import { DOMAIN, FULL_NAME, LONG_POST_LINE_COUNT } from "../lib/constants";
 import { TableOfContents } from "./TableOfContents";
 import { useMemo, useEffect, useRef } from "react";
 import { ProgressNotice } from "./ProgressNotice";
@@ -37,6 +37,12 @@ interface Props {
 
 export const Post = (props: Props) => {
   const articleRef = useRef<HTMLDivElement>(null);
+
+  // Long posts are tedious to navigate by scrolling, so they get the ⌘F/Ctrl+F
+  // heading search in the nav.
+  const isLongPost =
+    Boolean(props.post.contentHtml) &&
+    (props.post.lineCount ?? 0) >= LONG_POST_LINE_COUNT;
 
   const contentWithEmbeds = useMemo(() => {
     if (!props.post.contentHtml) return null;
@@ -239,7 +245,9 @@ export const Post = (props: Props) => {
         description={props.post.description}
         cover={ogCover}
       />
-      <Layout>
+      <Layout
+        searchableContentHtml={isLongPost ? props.post.contentHtml : undefined}
+      >
         <h1 className="font-bold sm:text-4xl text-3xl mt-6 dark:text-white">
           {props.post.title}
         </h1>

--- a/components/PostSearch.tsx
+++ b/components/PostSearch.tsx
@@ -1,0 +1,348 @@
+import { extractHeadings, PostHeading } from "../lib/extract-headings";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Command } from "lucide-react";
+import { FiSearch } from "react-icons/fi";
+
+interface Props {
+  contentHtml: string;
+}
+
+// How close to the top/bottom edge of the results the pointer has to sit
+// before the list starts scrolling itself, and how fast it goes once the
+// pointer is right on the edge.
+const AUTO_SCROLL_ZONE = 56;
+const AUTO_SCROLL_MAX_SPEED = 12;
+
+const escapeRegExp = (text: string) =>
+  text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// Wraps every occurrence of a search term in the heading text. Splitting on a
+// regex with one capture group leaves the matches at the odd indices.
+const highlight = (text: string, terms: string[]) => {
+  if (terms.length === 0) return text;
+
+  const pattern = new RegExp(`(${terms.map(escapeRegExp).join("|")})`, "ig");
+
+  return text.split(pattern).map((piece, index) =>
+    index % 2 === 1 ? (
+      <mark key={index} className="bg-transparent text-primary font-semibold">
+        {piece}
+      </mark>
+    ) : (
+      <span key={index}>{piece}</span>
+    ),
+  );
+};
+
+export const PostSearch = (props: Props) => {
+  const [headings, setHeadings] = useState<PostHeading[]>([]);
+  const [isMac, setIsMac] = useState<boolean | null>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const activeItemRef = useRef<HTMLLIElement>(null);
+  // Signed pixels per frame; 0 means the pointer isn't in an edge zone.
+  const autoScrollSpeed = useRef(0);
+  const autoScrollFrame = useRef(0);
+
+  useEffect(() => {
+    setHeadings(extractHeadings(props.contentHtml));
+  }, [props.contentHtml]);
+
+  useEffect(() => {
+    setIsMac(/Mac|iPhone|iPad|iPod/i.test(navigator.userAgent));
+  }, []);
+
+  const terms = useMemo(
+    () => query.trim().toLowerCase().split(/\s+/).filter(Boolean),
+    [query],
+  );
+
+  // Every term has to appear somewhere in the heading or the section it sits
+  // in, so word order and the words in between don't matter ("day 3 utp"
+  // finds "UTP Cables" under "Day 3").
+  const results = useMemo(() => {
+    if (terms.length === 0) return headings;
+    return headings.filter((heading) => {
+      const haystack = `${heading.parent ?? ""} ${heading.text}`.toLowerCase();
+      return terms.every((term) => haystack.includes(term));
+    });
+  }, [headings, terms]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query]);
+
+  const close = () => {
+    setIsOpen(false);
+    setQuery("");
+    triggerRef.current?.focus();
+  };
+
+  const goTo = (id: string) => {
+    const element = document.getElementById(id);
+    if (!element) return;
+
+    setIsOpen(false);
+    setQuery("");
+    window.history.pushState(null, "", `#${id}`);
+
+    const reducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    element.scrollIntoView({ behavior: reducedMotion ? "auto" : "smooth" });
+  };
+
+  // ⌘F on macOS, Ctrl+F everywhere else — deliberately taking over the
+  // browser's own find for these posts.
+  useEffect(() => {
+    // Nothing to search means the browser keeps its own find.
+    if (headings.length === 0) return;
+
+    const handleKeydown = (event: KeyboardEvent) => {
+      const modifier = isMac ? event.metaKey : event.ctrlKey;
+      if (!modifier || event.key.toLowerCase() !== "f") return;
+
+      event.preventDefault();
+
+      if (isOpen) {
+        inputRef.current?.select();
+      } else {
+        setIsOpen(true);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeydown);
+    return () => window.removeEventListener("keydown", handleKeydown);
+  }, [headings.length, isMac, isOpen]);
+
+  useEffect(() => {
+    if (isOpen) inputRef.current?.focus();
+  }, [isOpen]);
+
+  // Keep the highlighted result inside the scrollable list.
+  useEffect(() => {
+    const list = listRef.current;
+    const item = activeItemRef.current;
+    // Auto-scrolling already puts the pointer's row on the edge on purpose,
+    // so don't fight it by pulling that row fully into view.
+    if (!list || !item || autoScrollSpeed.current !== 0) return;
+
+    const itemBottom = item.offsetTop + item.offsetHeight;
+    if (item.offsetTop < list.scrollTop) {
+      list.scrollTop = item.offsetTop;
+    } else if (itemBottom > list.scrollTop + list.clientHeight) {
+      list.scrollTop = itemBottom - list.clientHeight;
+    }
+  }, [activeIndex, results]);
+
+  const stopAutoScroll = useCallback(() => {
+    cancelAnimationFrame(autoScrollFrame.current);
+    autoScrollFrame.current = 0;
+    autoScrollSpeed.current = 0;
+  }, []);
+
+  const runAutoScroll = useCallback(() => {
+    autoScrollFrame.current = requestAnimationFrame(runAutoScroll);
+    if (listRef.current) {
+      listRef.current.scrollTop += autoScrollSpeed.current;
+    }
+  }, []);
+
+  // Resting the pointer near the top or bottom of the results scrolls them in
+  // that direction, faster the closer to the edge it gets. The bottom zone
+  // reaches past the list so the footer strip counts as "the bottom" too.
+  const handleAutoScroll = (event: React.MouseEvent) => {
+    const list = listRef.current;
+    if (!list || list.scrollHeight <= list.clientHeight) {
+      stopAutoScroll();
+      return;
+    }
+
+    const { top, bottom } = list.getBoundingClientRect();
+    const y = event.clientY;
+
+    let speed = 0;
+    if (y > bottom - AUTO_SCROLL_ZONE) {
+      const depth = Math.min(y - (bottom - AUTO_SCROLL_ZONE), AUTO_SCROLL_ZONE);
+      speed = (depth / AUTO_SCROLL_ZONE) * AUTO_SCROLL_MAX_SPEED;
+    } else if (y >= top && y < top + AUTO_SCROLL_ZONE) {
+      const depth = Math.min(top + AUTO_SCROLL_ZONE - y, AUTO_SCROLL_ZONE);
+      speed = -(depth / AUTO_SCROLL_ZONE) * AUTO_SCROLL_MAX_SPEED;
+    }
+
+    if (speed === 0) {
+      stopAutoScroll();
+      return;
+    }
+
+    autoScrollSpeed.current = speed;
+    if (!autoScrollFrame.current) runAutoScroll();
+  };
+
+  // Never leave a frame running once the dialog is gone.
+  useEffect(() => {
+    if (!isOpen) stopAutoScroll();
+    return stopAutoScroll;
+  }, [isOpen, stopAutoScroll]);
+
+  const handleDialogKeydown = (event: React.KeyboardEvent) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      close();
+      return;
+    }
+
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      if (results.length === 0) return;
+      const step = event.key === "ArrowDown" ? 1 : -1;
+      setActiveIndex(
+        (index) => (index + step + results.length) % results.length,
+      );
+      return;
+    }
+
+    if (event.key === "Enter") {
+      event.preventDefault();
+      const heading = results[activeIndex];
+      if (heading) goTo(heading.id);
+    }
+  };
+
+  if (headings.length === 0) return null;
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        onClick={() => setIsOpen(true)}
+        title="Search headings"
+        aria-label="Search headings"
+        aria-haspopup="dialog"
+        aria-expanded={isOpen}
+        className="flex items-center justify-center gap-1 focus:ring-4 ring-primary outline-none bg-gray-100
+        text-black h-9 px-2 duration-300 md:hover:bg-gray-200 dark:bg-gray-800 md:dark:hover:bg-gray-900
+        dark:text-white rounded-lg focus:ring-offset-2 dark:ring-offset-black"
+      >
+        <span className="flex items-center justify-center min-w-[1.75rem]">
+          {isMac === null ? null : isMac ? (
+            <Command className="h-4 w-4" strokeWidth={2.25} />
+          ) : (
+            <span className="text-[11px] font-semibold leading-none">CTRL</span>
+          )}
+        </span>
+        <span className="text-xs font-semibold leading-none">+</span>
+        <span className="text-xs font-semibold leading-none">F</span>
+      </button>
+
+      {isOpen && typeof document !== "undefined"
+        ? createPortal(
+            <div
+              className="fixed inset-0 z-[100] flex items-start justify-center px-4 pt-24 sm:pt-32"
+              onKeyDown={handleDialogKeydown}
+            >
+              <div
+                className="absolute inset-0 bg-black/40 backdrop-blur-[2px]"
+                onClick={close}
+                aria-hidden="true"
+              />
+              <div
+                role="dialog"
+                aria-modal="true"
+                aria-label="Search headings"
+                onMouseMove={handleAutoScroll}
+                onMouseLeave={stopAutoScroll}
+                className="relative w-full sm:w-[36rem] rounded-lg border border-teal-100 bg-white shadow-xl
+                dark:border-teal-900 dark:bg-[#10161a] overflow-hidden"
+              >
+                <div className="flex items-center gap-2 border-b border-teal-100 px-4 dark:border-teal-900">
+                  <FiSearch className="shrink-0 text-base text-gray-500 dark:text-gray-400" />
+                  <input
+                    ref={inputRef}
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                    placeholder="Jump to a heading..."
+                    aria-label="Search headings"
+                    className="w-full bg-transparent py-3 text-base text-black outline-none
+                    placeholder:text-gray-500 dark:text-white dark:placeholder:text-gray-400"
+                  />
+                  <button
+                    onClick={close}
+                    title="Close"
+                    className="shrink-0 rounded border border-teal-100 px-1.5 py-0.5 text-[11px] font-semibold
+                    text-gray-500 duration-300 hover:text-black focus:ring-4 ring-primary outline-none
+                    dark:border-teal-900 dark:text-gray-400 dark:hover:text-white"
+                  >
+                    Esc
+                  </button>
+                </div>
+
+                {results.length === 0 ? (
+                  <p className="px-4 py-6 text-sm text-gray-600 dark:text-gray-300">
+                    No headings match &quot;{query.trim()}&quot;.
+                  </p>
+                ) : (
+                  <ul ref={listRef} className="max-h-80 overflow-auto py-2">
+                    {results.map((heading, index) => (
+                      <li
+                        key={`${heading.id}-${index}`}
+                        ref={index === activeIndex ? activeItemRef : null}
+                      >
+                        <button
+                          onClick={() => goTo(heading.id)}
+                          onMouseEnter={() => {
+                            // Rows sliding past a still pointer shouldn't
+                            // yank the highlight around.
+                            if (autoScrollSpeed.current === 0) {
+                              setActiveIndex(index);
+                            }
+                          }}
+                          className={`block w-full pr-4 py-2 text-left text-sm duration-150 ${
+                            heading.level === 4
+                              ? "pl-10"
+                              : heading.level === 3
+                                ? "pl-7"
+                                : "pl-4"
+                          } ${
+                            index === activeIndex
+                              ? "bg-gray-100 text-black dark:bg-gray-800 dark:text-white"
+                              : "text-gray-600 dark:text-gray-300"
+                          }`}
+                        >
+                          {heading.parent ? (
+                            <span className="text-gray-500 dark:text-gray-400">
+                              {highlight(heading.parent, terms)}
+                              <span className="px-1.5">/</span>
+                            </span>
+                          ) : null}
+                          {highlight(heading.text, terms)}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+
+                <div
+                  className="hidden items-center gap-4 border-t border-teal-100 px-4 py-2 text-[11px]
+                  text-gray-500 dark:border-teal-900 dark:text-gray-400 sm:flex"
+                >
+                  <span>↑ ↓ to navigate</span>
+                  <span>↵ to jump</span>
+                  <span className="ml-auto">
+                    {results.length} of {headings.length} headings
+                  </span>
+                </div>
+              </div>
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+};

--- a/components/TableOfContents.tsx
+++ b/components/TableOfContents.tsx
@@ -1,10 +1,5 @@
+import { extractHeadings, PostHeading } from "../lib/extract-headings";
 import { useEffect, useRef, useState } from "react";
-
-interface Heading {
-  level: number;
-  text: string;
-  id: string;
-}
 
 interface Props {
   contentHtml: string;
@@ -16,7 +11,7 @@ interface Props {
 const ACTIVE_LINE = 110;
 
 export const TableOfContents = (props: Props) => {
-  const [headings, setHeadings] = useState<Heading[]>([]);
+  const [headings, setHeadings] = useState<PostHeading[]>([]);
   const [activeId, setActiveId] = useState<string>("");
   const navRef = useRef<HTMLElement>(null);
   const itemRefs = useRef(new Map<string, HTMLLIElement>());
@@ -27,19 +22,7 @@ export const TableOfContents = (props: Props) => {
   const settleTimer = useRef<ReturnType<typeof setTimeout>>();
 
   useEffect(() => {
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(props.contentHtml, "text/html");
-    const headingElements = doc.querySelectorAll("h2[id], h3[id], h4[id]");
-
-    const extractedHeadings: Heading[] = Array.from(headingElements).map(
-      (heading) => ({
-        id: heading.id,
-        text: heading.textContent || "",
-        level: parseInt(heading.tagName.substring(1)),
-      }),
-    );
-
-    setHeadings(extractedHeadings);
+    setHeadings(extractHeadings(props.contentHtml));
   }, [props.contentHtml]);
 
   useEffect(() => {
@@ -164,7 +147,11 @@ export const TableOfContents = (props: Props) => {
               }
             }}
             className={`${
-              heading.level === 4 ? "pl-9" : heading.level === 3 ? "pl-6" : "pl-3"
+              heading.level === 4
+                ? "pl-9"
+                : heading.level === 3
+                  ? "pl-6"
+                  : "pl-3"
             } transition-colors duration-200`}
           >
             <button

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -8,6 +8,8 @@ export const SUBJECT_OF_STUDY = "Computer Science (Software Engineering)";
 export const STUDYING_UNTIL = new Date("2027-07-01T00:00:00Z");
 export const WEBSOCKET_URL = "wss://api.lanyard.rest/socket";
 export const YEAR_STARTED_PROGRAMMING_PROFESSIONALLY = 2023;
+// Posts at least this many lines long get the in-post heading search.
+export const LONG_POST_LINE_COUNT = 1000;
 export const AVATAR = "Secondary_Dark_Short_Sig_Avatar";
 export const MUSIC_STREAMING_PLATFORM = "YouTube Music";
 export const SWITCH_FRIEND_CODE = "SW-8471-1596-9212";

--- a/lib/extract-headings.ts
+++ b/lib/extract-headings.ts
@@ -1,0 +1,33 @@
+export interface PostHeading {
+  /** Text of the nearest enclosing heading, when there is one. */
+  parent?: string;
+  level: number;
+  text: string;
+  id: string;
+}
+
+/**
+ * Pulls every anchored heading out of a post's rendered HTML, in document
+ * order. Browser only — `DOMParser` doesn't exist on the server.
+ */
+export const extractHeadings = (contentHtml: string): PostHeading[] => {
+  if (typeof window === "undefined") return [];
+
+  const doc = new DOMParser().parseFromString(contentHtml, "text/html");
+  // Heading text seen so far, indexed by level, so a heading can name the
+  // section it sits in.
+  const openHeadings: string[] = [];
+
+  return Array.from(doc.querySelectorAll("h2[id], h3[id], h4[id]")).map(
+    (heading) => {
+      const level = parseInt(heading.tagName.substring(1));
+      const text = heading.textContent || "";
+      const parent = openHeadings.slice(0, level).reverse().find(Boolean);
+
+      openHeadings[level] = text;
+      openHeadings.length = level + 1;
+
+      return { id: heading.id, text, level, parent };
+    },
+  );
+};

--- a/lib/post.ts
+++ b/lib/post.ts
@@ -96,6 +96,7 @@ export const getPostData = async (slug: string, dir: string) => {
     slug,
     contentHtml,
     sections,
+    lineCount: matterResult.content.split("\n").length,
     ...matterResult.data,
   };
 };

--- a/types/post.ts
+++ b/types/post.ts
@@ -5,6 +5,7 @@ export interface Post {
   last_updated_date: string;
   description: string;
   contentHtml: string;
+  lineCount?: number;
   finished: boolean;
   pinned?: boolean;
   filter: string;


### PR DESCRIPTION
This pull request introduces a heading search feature for long posts, making it easier for users to quickly navigate large articles by searching for headings. The feature is automatically enabled for posts with at least 1000 lines. The implementation includes a new `PostSearch` component, updates to the navigation and post layout, and a shared heading extraction utility. Additionally, the Table of Contents code is refactored to use the new heading extraction logic.

**New heading search feature for long posts:**

- Added a `PostSearch` component that provides a keyboard-accessible dialog (triggered by ⌘F/Ctrl+F) to search and jump to headings within long posts. It features auto-scrolling, keyboard navigation, and highlights search terms. (`components/PostSearch.tsx`)
- Posts with at least 1000 lines now automatically enable the heading search in the navigation bar. The threshold is defined by the new `LONG_POST_LINE_COUNT` constant. (`lib/constants.ts`, `components/Post.tsx`, `types/post.ts`, `lib/post.ts`) [[1]](diffhunk://#diff-561ab956a0b904914573a9544f92493c5493b6e14d30372365bcdd9c5c7f6e59R11-R12) [[2]](diffhunk://#diff-426c728781e4d0d739ec1531a3598bc781d47e3dafa62d57fa4486d396d31ad0R41-R46) [[3]](diffhunk://#diff-426c728781e4d0d739ec1531a3598bc781d47e3dafa62d57fa4486d396d31ad0L242-R250) [[4]](diffhunk://#diff-9fb50c65549c72b614485980c8fdd75d1f5b206303932d3aaac62298184e0bffR99) [[5]](diffhunk://#diff-8f15dc85fa334bc0dc85127979a24c01c3326e9cd280b07eb2dbe8d7407800d6R8)

**Integration and navigation updates:**

- Updated the `Layout` and `Nav` components to accept and forward the `searchableContentHtml` prop, rendering the `PostSearch` button in the navigation bar when applicable. (`components/Layout.tsx`, `components/Nav.tsx`) [[1]](diffhunk://#diff-0348808fef58c5568d86baa15ff97eeb8e2990127b9ffbaeb0ee7b59324d8721R6-R7) [[2]](diffhunk://#diff-0348808fef58c5568d86baa15ff97eeb8e2990127b9ffbaeb0ee7b59324d8721R41) [[3]](diffhunk://#diff-99c1d55953852b4532610c046612748e9daea0f4455ba2881572ed13a096aeeaR3-R12) [[4]](diffhunk://#diff-99c1d55953852b4532610c046612748e9daea0f4455ba2881572ed13a096aeeaR46-R51)

**Shared heading extraction logic:**

- Introduced a new `extractHeadings` utility that parses HTML and extracts heading information, including parent section context, for consistent use in both the Table of Contents and heading search. (`lib/extract-headings.ts`)

**Table of Contents refactor:**

- Refactored the Table of Contents component to use the new `extractHeadings` utility and the shared `PostHeading` interface, improving consistency and maintainability. (`components/TableOfContents.tsx`) [[1]](diffhunk://#diff-1c4973dc212e587ec18235f310e988605108283edd3f26879596c810e828ccd0R1-L8) [[2]](diffhunk://#diff-1c4973dc212e587ec18235f310e988605108283edd3f26879596c810e828ccd0L19-R14) [[3]](diffhunk://#diff-1c4973dc212e587ec18235f310e988605108283edd3f26879596c810e828ccd0L30-R25) [[4]](diffhunk://#diff-1c4973dc212e587ec18235f310e988605108283edd3f26879596c810e828ccd0L167-R154)